### PR TITLE
moved vendor concat and uglify into separate tasks

### DIFF
--- a/generators/app/templates/_gulpfile.js
+++ b/generators/app/templates/_gulpfile.js
@@ -147,18 +147,22 @@ gulp.task('sass', function () {
 });
 
 // thanks @esvendsen !!!
-gulp.task('vendor', ['vendor-js']);
 gulp.task('vendor-js', function() {
     var jsRegex = (/.*\.js$/i);
     return gulp.src(mbf({ filter: jsRegex }))
         //.pipe(debug())
-        .pipe(sourcemaps.init())
         .pipe(concat('vendor.js'))
-        //.pipe(gulp.dest('app/scripts'))
+        .pipe(gulp.dest('app/scripts'));
+});
+// identify vendor-js as a dependency which must complete before vendor-uglify can run
+gulp.task('vendor-uglify', ['vendor-js'], function() {
+    return gulp.src('app/scripts/vendor.js')
+        .pipe(sourcemaps.init())
         .pipe(uglify())
         .pipe(rename({ suffix: '.min' }))
         .pipe(gulp.dest('app/scripts'));
 });
+gulp.task('vendor', ['vendor-js','vendor-uglify']);
 
 gulp.task('js', function() {
     return gulp.src('app/modules/**/*.js')


### PR DESCRIPTION
Finally got a chance to look into the slowness issue with the build.  Looks like the holdup is due to uglify, not main-bower-files. When the two tasks are separated out, the mbf task takes around 400 milliseconds while the uglify task takes about 15 seconds.

From what I can find, this is due to a [limitation inherent in gulp](https://github.com/terinjokes/gulp-uglify/issues/72)

Even though this PR doesn't fix anything, I figured I'd do it anyway so you can check out the difference for yourself.
