### PR TITLE
re-adding sourcemaps write function call for vendor-uglify task

### DIFF
--- a/generators/app/templates/_gulpfile.js
+++ b/generators/app/templates/_gulpfile.js
@@ -160,6 +160,7 @@ gulp.task('vendor-uglify', ['vendor-js'], function() {
         .pipe(sourcemaps.init())
         .pipe(uglify())
         .pipe(rename({ suffix: '.min' }))
+		.pipe(sourcemaps.write())
         .pipe(gulp.dest('app/scripts'));
 });
 gulp.task('vendor', ['vendor-js','vendor-uglify']);


### PR DESCRIPTION
Forgot to include sourcemaps.write() when I separated out the vendor tasks.
